### PR TITLE
Fix compilation errors after method GetDefaultHostIP was removed

### DIFF
--- a/pkg/kubeadm/cmd/init.go
+++ b/pkg/kubeadm/cmd/init.go
@@ -27,6 +27,7 @@ import (
 	kubemaster "k8s.io/kubernetes/pkg/kubeadm/master"
 	kubeadmutil "k8s.io/kubernetes/pkg/kubeadm/util"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	netutil "k8s.io/kubernetes/pkg/util/net"
 )
 
 var (
@@ -59,11 +60,11 @@ func NewCmdInit(out io.Writer, params *kubeadmapi.BootstrapParams) *cobra.Comman
 
 func RunInit(out io.Writer, cmd *cobra.Command, args []string, params *kubeadmapi.BootstrapParams) error {
 	if params.Discovery.ListenIP == "" {
-		ip, err := kubeadmutil.GetDefaultHostIP()
+		ip, err := netutil.ChooseHostInterface()
 		if err != nil {
 			return err
 		}
-		params.Discovery.ListenIP = ip
+		params.Discovery.ListenIP = string(ip)
 	}
 	if err := kubemaster.CreateTokenAuthFile(params); err != nil {
 		return err

--- a/pkg/kubeadm/cmd/manual.go
+++ b/pkg/kubeadm/cmd/manual.go
@@ -98,7 +98,7 @@ func NewCmdManualBootstrapInitMaster(out io.Writer, params *kubeadmapi.Bootstrap
 				if err != nil {
 					return fmt.Errorf("Unable to autodetect IP address [%s], please specify with --listen-ip", err)
 				}
-				params.Discovery.ListenIP = ip
+				params.Discovery.ListenIP = string(ip)
 			}
 			if err := kubemaster.CreateTokenAuthFile(params); err != nil {
 				return err


### PR DESCRIPTION
```
# k8s.io/kubernetes/pkg/kubeadm/cmd
pkg/kubeadm/cmd/init.go:62: undefined: kubeadmutil.GetDefaultHostIP
pkg/kubeadm/cmd/manual.go:101: cannot use ip (type "net".IP) as type string in assignment
Makefile:79: recipe for target 'all' failed
make: *** [all] Error 1
!!! Error in ./build/../build/common.sh:624
  '"${docker_cmd[@]}" "$@"' exited with status 2
Call stack:
  1: ./build/../build/common.sh:624 kube::build::run_build_command(...)
  2: ./build/run.sh:30 main(...)
Exiting with status 1
```
