### PR TITLE
Check that sever API provides certificates capabilities

### DIFF
--- a/pkg/kubeadm/cmd/cmd.go
+++ b/pkg/kubeadm/cmd/cmd.go
@@ -73,7 +73,7 @@ func NewKubeadmCommand(f *cmdutil.Factory, in io.Reader, out, err io.Writer, env
 	// TODO(phase2) detect interactive vs non-interactive use and adjust output accordingly
 	// i.e. make it automation friendly
 	//
-	// TODO(phase2) create an bastraction that defines files and the content that needs to
+	// TODO(phase2) create an abstraction that defines files and the content that needs to
 	// be written to disc and write it all in one go at the end as we have a lot of
 	// crapy little files written from different parts of this code; this could also
 	// be useful for testing

--- a/pkg/kubeadm/node/csr.go
+++ b/pkg/kubeadm/node/csr.go
@@ -21,7 +21,10 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/apis/certificates"
 	unversionedcertificates "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	kubeadmapi "k8s.io/kubernetes/pkg/kubeadm/api"
@@ -60,6 +63,12 @@ func PerformTLSBootstrap(params *kubeadmapi.BootstrapParams, apiEndpoint string,
 		return nil, fmt.Errorf("<node/csr> failed to create API client configuration [%s]", err)
 	}
 
+	err = checkCertsAPI(bootstrapClientConfig)
+
+	if err != nil {
+		return nil, fmt.Errorf("<node/csr> API compatibility error [%s]", err)
+	}
+
 	client, err := unversionedcertificates.NewForConfig(bootstrapClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("<node/csr> failed to create API client [%s]", err)
@@ -87,4 +96,36 @@ func PerformTLSBootstrap(params *kubeadmapi.BootstrapParams, apiEndpoint string,
 	)
 
 	return finalConfig, nil
+}
+
+func checkCertsAPI(config *restclient.Config) error {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+
+	if err != nil {
+		return fmt.Errorf("failed to create API discovery client [%s]", err)
+	}
+
+	serverGroups, err := discoveryClient.ServerGroups()
+
+	if err != nil {
+		return fmt.Errorf("failed to retrieve a list of supported API objects [%s]", err)
+	}
+
+	for _, group := range serverGroups.Groups {
+		if group.Name == certificates.GroupName {
+			return nil
+		}
+	}
+
+	version, err := discoveryClient.ServerVersion()
+	serverVersion := version.String()
+
+	if err != nil {
+		serverVersion = "N/A"
+	}
+
+	// Due to changes in API namespaces for certificates
+	// https://github.com/kubernetes/kubernetes/pull/31887/
+	// it is compatible only with versions released after v1.4.0-beta.0
+	return fmt.Errorf("installed Kubernetes API server version \"%s\" does not support certificates signing request use v1.4.0 or newer", serverVersion)
 }


### PR DESCRIPTION
Explicitly check that API provides certificates namespace, in case of failure provide user friendly message.
